### PR TITLE
Remove trailing comma which causes syntax error in example.

### DIFF
--- a/source/developer/languages/python/advanced-deployment.html.adoc
+++ b/source/developer/languages/python/advanced-deployment.html.adoc
@@ -92,7 +92,7 @@ mod_wsgi.server.start(
   '--trust-proxy-header', 'X-Forwarded-Proto',
   '--url-alias', '/static/', './static/',
   '--application-type', 'module',
-  '--entry-point', 'demo.wsgi',
+  '--entry-point', 'demo.wsgi'
 )
 --
 


### PR DESCRIPTION
See issue #21.
